### PR TITLE
feat" add background color to ContentSlideContainer for lazy loading

### DIFF
--- a/src/components/browse/content-slide/styled.ts
+++ b/src/components/browse/content-slide/styled.ts
@@ -1,10 +1,13 @@
 import Image from 'next/image'
 import styled from 'styled-components'
 
+import { colors } from '@/constants/theme'
+
 export const ContentSlideContainer = styled.div`
   position: relative;
   aspect-ratio: 16 / 9;
   min-width: min(24%, 300px);
+  background-color: ${colors.textDarkGrey};
 
   cursor: pointer;
 


### PR DESCRIPTION
- added a dark grey background color to `ContentSlideContainer` so that the slides are visible while the image loads