### PR TITLE
fix: add priority to next/image LCP components

### DIFF
--- a/src/components/browse/Billboard/Billboard.tsx
+++ b/src/components/browse/Billboard/Billboard.tsx
@@ -37,7 +37,7 @@ export const Billboard = () => {
 
   return (
     <BillboardContainer className='container'>
-      <BillboardImage src={imgUrl} alt='' fill />
+      <BillboardImage src={imgUrl} alt='' fill priority />
       <Vignette>
         <FeaturedContainer>
           <FeaturedTitle>{randomShow?.title || 'Loading...'}</FeaturedTitle>

--- a/src/components/shared/full-page-background/FullPageBackground.tsx
+++ b/src/components/shared/full-page-background/FullPageBackground.tsx
@@ -25,7 +25,7 @@ export const FullPageBackground = ({
 }: FullPageBackgroundProps) => {
   return (
     <PageBackground>
-      <PageBackgroundImage src={imageUrl} alt='' fill />
+      <PageBackgroundImage src={imageUrl} alt='' fill priority />
       <SemanticHeader>
         <RegNavbar noBorder />
       </SemanticHeader>

--- a/src/components/shared/hero-header/HeroHeader.tsx
+++ b/src/components/shared/hero-header/HeroHeader.tsx
@@ -18,6 +18,7 @@ export const HeroHeader = ({
         src='/images/misc/videodrome.jpg'
         alt=''
         fill
+        priority
         $noBgOnMobile={noBgOnMobile}
         sizes='100vw'
       />


### PR DESCRIPTION
- set `priority` option (next/image) on background images that appear within LCP components